### PR TITLE
Define APIs to convert Instants and Durations to/from "ticks"

### DIFF
--- a/src/duration.rs
+++ b/src/duration.rs
@@ -93,6 +93,26 @@ impl Duration {
         ((self.0 as u32 as u64 * 125_000_000) >> 29) as u32
     }
 
+    /// Return this duration as a number of "ticks".
+    ///
+    /// Note that length of a 'tick' is not guaranteed to represent
+    /// the same amount of time across different platforms, or from
+    /// one version of `coarsetime` to another.
+    #[inline]
+    pub fn as_ticks(&self) -> u64 {
+        self.as_u64()
+    }
+
+    /// Creates a new Duration from the specified number of "ticks".
+    ///
+    /// Note that length of a 'tick' is not guaranteed to represent
+    /// the same amount of time across different platforms, or from
+    /// one version of `coarsetime` to another.
+    #[inline]
+    pub fn from_ticks(ticks: u64) -> Duration {
+        Self::from_u64(ticks)
+    }
+
     #[doc(hidden)]
     #[inline]
     pub fn as_u64(&self) -> u64 {

--- a/src/instant.rs
+++ b/src/instant.rs
@@ -100,6 +100,25 @@ impl Instant {
         Self::now() - *self
     }
 
+    /// Return a representation of this instant as a number of "ticks".
+    ///
+    /// Note that length of a 'tick' is not guaranteed to represent
+    /// the same amount of time across different platforms, or from
+    /// one version of `coarsetime` to another.
+    ///
+    /// Note also that the instant represented by "0" ticks is
+    /// unspecified.  It is not guaranteed to be the same time across
+    /// different platforms, or from one version of `coarsetime` to
+    /// another.
+    ///
+    /// This API is mainly intended for applications that need to
+    /// store the value of an `Instant` in an
+    /// [`AtomicU64`](std::sync::atomic::AtomicU64).
+    #[inline]
+    pub fn as_ticks(&self) -> u64 {
+        self.as_u64()
+    }
+
     #[doc(hidden)]
     #[inline]
     pub fn as_u64(&self) -> u64 {


### PR DESCRIPTION
These APIs have the same behavior as the (undocumented) as_u64()
and from_u64() calls.  The choice of names is intended to convey
the idea that neither the units nor the zero-points defined by these
calls are specified.

Closes #17