### PR TITLE
fix: always use saturating sub

### DIFF
--- a/src/instant.rs
+++ b/src/instant.rs
@@ -220,34 +220,9 @@ impl Default for Instant {
 impl Sub<Instant> for Instant {
     type Output = Duration;
 
-    #[cfg(all(
-        unix,
-        not(any(
-            target_os = "macos",
-            target_os = "linux",
-            target_os = "android",
-            target_os = "freebsd",
-            target_os = "dragonfly"
-        ))
-    ))]
     #[inline]
     fn sub(self, other: Instant) -> Duration {
         Duration::from_u64(self.0.saturating_sub(other.0))
-    }
-
-    #[cfg(not(all(
-        unix,
-        not(any(
-            target_os = "macos",
-            target_os = "linux",
-            target_os = "android",
-            target_os = "freebsd",
-            target_os = "dragonfly"
-        ))
-    )))]
-    #[inline]
-    fn sub(self, other: Instant) -> Duration {
-        Duration::from_u64(self.0 - other.0)
     }
 }
 


### PR DESCRIPTION
Guarantees are weak, and we've seen crashes of `.elapsed()`.

https://gist.github.com/kogeler/5f4a3fe3dfaf9478f0d59e3e86c11c5f

Which is a linux based system.


---

Would you consider cutting a new release soon?