### PR TITLE
fix: compilation to WASM was failing due to name conflict on "Date"

### DIFF
--- a/src/clock.rs
+++ b/src/clock.rs
@@ -11,7 +11,7 @@ use once_cell::sync::Lazy;
 ))]
 use wasm_bindgen::prelude::*;
 
-use super::{Date, Duration};
+use super::Duration;
 
 #[cfg(all(
     any(target_arch = "wasm32", target_arch = "wasm64"),
@@ -39,7 +39,7 @@ impl Clock {
     #[inline]
     pub fn now_since_epoch() -> UnixTimeStamp {
         let offset = *CLOCK_OFFSET;
-        let unix_ts_now = Date::now().as_u64().wrapping_sub(offset);
+        let unix_ts_now = super::Date::now().as_u64().wrapping_sub(offset);
         Duration::from_u64(unix_ts_now)
     }
 
@@ -48,7 +48,7 @@ impl Clock {
     #[inline]
     pub fn recent_since_epoch() -> UnixTimeStamp {
         let offset = *CLOCK_OFFSET;
-        let unix_ts_now = Date::recent().as_u64().wrapping_sub(offset);
+        let unix_ts_now = super::Date::recent().as_u64().wrapping_sub(offset);
         Duration::from_u64(unix_ts_now)
     }
 
@@ -56,7 +56,7 @@ impl Clock {
     /// Date::update()
     #[inline]
     pub fn update() {
-        Date::update()
+        super::Date::update()
     }
 }
 
@@ -86,6 +86,6 @@ fn unix_ts() -> u64 {
 
 fn clock_offset() -> u64 {
     let unix_ts_now = unix_ts();
-    let instant_now = Date::now().as_u64();
+    let instant_now = super::Date::now().as_u64();
     instant_now.wrapping_sub(unix_ts_now)
 }


### PR DESCRIPTION
Hello,
I noticed this one this morning after a "cargo update". Fails only on WASM targets starting >= 0.1.25.
To reproduce run `cargo check --target wasm32-unknown-unknown`.
This should fix the issue