### PR TITLE
Use saturating arithmetic to avoid panics, throughout

### DIFF
--- a/src/duration.rs
+++ b/src/duration.rs
@@ -202,7 +202,8 @@ impl Div<u32> for Duration {
 
     #[inline]
     fn div(self, rhs: u32) -> Duration {
-        Duration(self.0 / rhs as u64)
+        // rust-lang/rust#122821
+        Duration(self.0.checked_div(rhs as u64).unwrap_or(u64::MAX))
     }
 }
 

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -19,19 +19,19 @@ impl Duration {
     /// Creates a new Duration from the specified number of days
     #[inline]
     pub fn from_days(days: u64) -> Duration {
-        Duration(_sec_to_u64(days * 86400))
+        Duration(_sec_to_u64(days.saturating_mul(86400)))
     }
 
     /// Creates a new Duration from the specified number of hours
     #[inline]
     pub fn from_hours(hours: u64) -> Duration {
-        Duration(_sec_to_u64(hours * 3600))
+        Duration(_sec_to_u64(hours.saturating_mul(3600)))
     }
 
     /// Creates a new Duration from the specified number of minutes
     #[inline]
     pub fn from_mins(mins: u64) -> Duration {
-        Duration(_sec_to_u64(mins * 60))
+        Duration(_sec_to_u64(mins.saturating_mul(60)))
     }
 
     /// Creates a new Duration from the specified number of seconds
@@ -154,7 +154,7 @@ impl Add for Duration {
 
     #[inline]
     fn add(self, rhs: Duration) -> Duration {
-        Duration(self.0 + rhs.0)
+        Duration(self.0.saturating_add(rhs.0))
     }
 }
 
@@ -170,7 +170,7 @@ impl Sub for Duration {
 
     #[inline]
     fn sub(self, rhs: Duration) -> Duration {
-        Duration(self.0 - rhs.0)
+        Duration(self.0.saturating_sub(rhs.0))
     }
 }
 
@@ -186,7 +186,7 @@ impl Mul<u32> for Duration {
 
     #[inline]
     fn mul(self, rhs: u32) -> Duration {
-        Duration(self.0 * rhs as u64)
+        Duration(self.0.saturating_mul(rhs as u64))
     }
 }
 

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -164,6 +164,7 @@ impl Add for Duration {
 
 impl AddAssign for Duration {
     #[inline]
+    #[allow(clippy::arithmetic_side_effects)] // clippy#11220
     fn add_assign(&mut self, rhs: Duration) {
         *self = *self + rhs;
     }
@@ -180,6 +181,7 @@ impl Sub for Duration {
 
 impl SubAssign for Duration {
     #[inline]
+    #[allow(clippy::arithmetic_side_effects)] // clippy#11220
     fn sub_assign(&mut self, rhs: Duration) {
         *self = *self - rhs;
     }
@@ -196,6 +198,7 @@ impl Mul<u32> for Duration {
 
 impl MulAssign<u32> for Duration {
     #[inline]
+    #[allow(clippy::arithmetic_side_effects)] // clippy#11220
     fn mul_assign(&mut self, rhs: u32) {
         *self = *self * rhs;
     }
@@ -213,6 +216,7 @@ impl Div<u32> for Duration {
 
 impl DivAssign<u32> for Duration {
     #[inline]
+    #[allow(clippy::arithmetic_side_effects)] // clippy#11220
     fn div_assign(&mut self, rhs: u32) {
         *self = *self / rhs;
     }

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -72,24 +72,28 @@ impl Duration {
 
     /// Returns the number of whole milliseconds represented by this duration
     #[inline]
+    #[allow(clippy::arithmetic_side_effects)] // false positive
     pub fn as_millis(&self) -> u64 {
         ((self.0 as u128 * 125) >> 29) as u64
     }
 
     /// Returns the number of whole microseconds represented by this duration
     #[inline]
+    #[allow(clippy::arithmetic_side_effects)] // false positive
     pub fn as_micros(&self) -> u64 {
         ((self.0 as u128 * 125_000) >> 29) as u64
     }
 
     /// Returns the number of whole nanoseconds represented by this duration
     #[inline]
+    #[allow(clippy::arithmetic_side_effects)] // false positive
     pub fn as_nanos(&self) -> u64 {
         ((self.0 as u128 * 125_000_000) >> 29) as u64
     }
 
     /// Returns the nanosecond precision represented by this duration
     #[inline]
+    #[allow(clippy::arithmetic_side_effects)] // false positive
     pub fn subsec_nanos(&self) -> u32 {
         ((self.0 as u32 as u64 * 125_000_000) >> 29) as u32
     }
@@ -226,4 +230,12 @@ impl From<time::Duration> for Duration {
     fn from(duration_sys: time::Duration) -> Duration {
         Duration::new(duration_sys.as_secs(), duration_sys.subsec_nanos())
     }
+}
+
+#[test]
+fn no_overflow() {
+    let _: u64 = Duration(u64::MAX).as_millis();
+    let _: u64 = Duration(u64::MAX).as_micros();
+    let _: u64 = Duration(u64::MAX).as_nanos();
+    let _: u32 = Duration(u64::MAX).subsec_nanos();
 }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -4,12 +4,14 @@ pub fn _sec_to_u64(sec: u64) -> u64 {
 }
 
 #[inline]
+#[allow(clippy::arithmetic_side_effects)] // we're careful not to overflow
 pub fn _millis_to_u64(millis: u64) -> u64 {
     let secs = millis / 1_000;
     (secs << 32) | ((millis - secs * 1_000) << 22)
 }
 
 #[inline]
+#[allow(clippy::arithmetic_side_effects)] // we're careful not to overflow
 pub fn _nsecs_to_u64(nsecs: u64) -> u64 {
     let secs = nsecs / 1_000_000_000;
     _timespec_to_u64(secs, (nsecs - secs * 1_000_000_000) as u32)
@@ -21,13 +23,27 @@ macro_rules! ts_tv_normalise { { $sec:ident, $subsec:ident, $div:expr } => {
 } }
 
 #[inline]
+#[allow(clippy::arithmetic_side_effects)] // we're careful not to overflow
 pub fn _timespec_to_u64(mut tp_sec: u64, mut tp_nsec: u32) -> u64 {
     ts_tv_normalise!(tp_sec, tp_nsec, 1_000_000_000);
     (tp_sec << 32) | ((tp_nsec as u64 * 9_223_372_037) >> 31)
 }
 
 #[inline]
+#[allow(clippy::arithmetic_side_effects)] // we're careful not to overflow
 pub fn _timeval_to_u64(mut tv_sec: u64, mut tv_usec: u32) -> u64 {
     ts_tv_normalise!(tv_sec, tv_usec, 1_000_000);
     (tv_sec << 32) | ((tv_usec as u64 * 9_223_372_036_855) >> 31)
+}
+
+#[test]
+fn no_overflow() {
+    let _: u64 = _millis_to_u64(0);
+    let _: u64 = _millis_to_u64(u64::MAX);
+    let _: u64 = _nsecs_to_u64(0);
+    let _: u64 = _nsecs_to_u64(u64::MAX);
+    let _: u64 = _timespec_to_u64(0, 0);
+    let _: u64 = _timespec_to_u64(0, u32::MAX);
+    let _: u64 = _timespec_to_u64(u64::MAX, 0);
+    let _: u64 = _timespec_to_u64(u64::MAX, u32::MAX);
 }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -15,12 +15,19 @@ pub fn _nsecs_to_u64(nsecs: u64) -> u64 {
     _timespec_to_u64(secs, (nsecs - secs * 1_000_000_000) as u32)
 }
 
+macro_rules! ts_tv_normalise { { $sec:ident, $subsec:ident, $div:expr } => {
+    $sec = $sec.saturating_add(($subsec / $div) as _);
+    $subsec %= $div;
+} }
+
 #[inline]
-pub fn _timespec_to_u64(tp_sec: u64, tp_nsec: u32) -> u64 {
+pub fn _timespec_to_u64(mut tp_sec: u64, mut tp_nsec: u32) -> u64 {
+    ts_tv_normalise!(tp_sec, tp_nsec, 1_000_000_000);
     (tp_sec << 32) | ((tp_nsec as u64 * 9_223_372_037) >> 31)
 }
 
 #[inline]
-pub fn _timeval_to_u64(tv_sec: u64, tv_usec: u32) -> u64 {
+pub fn _timeval_to_u64(mut tv_sec: u64, mut tv_usec: u32) -> u64 {
+    ts_tv_normalise!(tv_sec, tv_usec, 1_000_000);
     (tv_sec << 32) | ((tv_usec as u64 * 9_223_372_036_855) >> 31)
 }

--- a/src/instant.rs
+++ b/src/instant.rs
@@ -261,7 +261,7 @@ impl Sub<Duration> for Instant {
 
     #[inline]
     fn sub(self, rhs: Duration) -> Instant {
-        Instant(self.0 - rhs.as_u64())
+        Instant(self.0.saturating_sub(rhs.as_u64()))
     }
 }
 
@@ -277,7 +277,7 @@ impl Add<Duration> for Instant {
 
     #[inline]
     fn add(self, rhs: Duration) -> Instant {
-        Instant(self.0 + rhs.as_u64())
+        Instant(self.0.saturating_add(rhs.as_u64()))
     }
 }
 

--- a/src/instant.rs
+++ b/src/instant.rs
@@ -94,6 +94,7 @@ impl Instant {
 
     /// Returns the amount of time elapsed from another instant to this one
     #[inline]
+    #[allow(clippy::arithmetic_side_effects)] // clippy#11220
     pub fn duration_since(&self, earlier: Instant) -> Duration {
         *self - earlier
     }
@@ -101,6 +102,7 @@ impl Instant {
     /// Returns the amount of time elapsed between the this instant was created
     /// and the latest update
     #[inline]
+    #[allow(clippy::arithmetic_side_effects)] // clippy#11220
     pub fn elapsed_since_recent(&self) -> Duration {
         Self::recent() - *self
     }
@@ -109,6 +111,7 @@ impl Instant {
     ///
     /// This function also updates the stored instant.
     #[inline]
+    #[allow(clippy::arithmetic_side_effects)] // clippy#11220
     pub fn elapsed(&self) -> Duration {
         Self::now() - *self
     }
@@ -267,6 +270,7 @@ impl Sub<Duration> for Instant {
 
 impl SubAssign<Duration> for Instant {
     #[inline]
+    #[allow(clippy::arithmetic_side_effects)] // clippy#11220
     fn sub_assign(&mut self, rhs: Duration) {
         *self = *self - rhs;
     }
@@ -283,6 +287,7 @@ impl Add<Duration> for Instant {
 
 impl AddAssign<Duration> for Instant {
     #[inline]
+    #[allow(clippy::arithmetic_side_effects)] // clippy#11220
     fn add_assign(&mut self, rhs: Duration) {
         *self = *self + rhs;
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@
 //! Windows and Unix-like systems are supported.
 
 #![allow(clippy::trivially_copy_pass_by_ref)]
+#![warn(clippy::arithmetic_side_effects)]
 #![cfg_attr(feature = "nightly", feature(test))]
 
 mod clock;


### PR DESCRIPTION
Hi.  We're using this crate, but we noticed that it has some places where it uses panicking arithmetic.  In our project we want to avoid panics due to time overflows (which might arise from weird clock behaviour, or improper parameters in our time calculations).

In this MR I propose to avoid panics by always saturating.  Unlike the proposal in #20, I'm not adding `.saturating_...` methods.  Instead, we just always saturate.  It seems to me that this is likely to be most useful to coarsetime's callers.

But, if you don't agree, I'm happy to make an alternative MR which adds separate `.saturating_...`, and leave the "normal" arithmetic and conversions to panic.  Please let me know what you think.

To make sure I found all the places, and that new panics don't arise, I enabled the `clippy::arithmetic_side_effects` lint.  That lint is rather stupid, unfortunately, so a fair few suppressions are needed.

Thanks for your attention.