### PR TITLE
Run clippy in CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,6 +23,7 @@ environment:
 install:
   - curl -sSf -o rustup-init.exe https://win.rustup.rs
   - rustup-init.exe --default-host %TARGET% --default-toolchain %CHANNEL% -y
+  - rustup-init.exe component add clippy
   - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
   - rustc -Vv
   - cargo -V
@@ -33,3 +34,4 @@ test_script:
   - cargo build --verbose
   - cargo doc
   - cargo test
+  - cargo clippy


### PR DESCRIPTION
Right now the tree is clippy clean, so there's no need to add suppressions (let alone change anything).

In #29 I propose to enable a clippy lint.  This will only be properly effective if we run clippy in CI.

I don't know much about appveyor.  And the CI seems to run on Windows (which surprised me) which I also know almost nothing about.  I'm hoping that this change is correct, but I  may need to iterate through the CI.