### PR TITLE
Add saturating and checked operations in Instant and Duration

### DIFF
--- a/src/duration.rs
+++ b/src/duration.rs
@@ -138,6 +138,41 @@ impl Duration {
     pub fn abs_diff(&self, other: Duration) -> Duration {
         Duration(self.0.abs_diff(other.0))
     }
+
+    #[inline]
+    pub fn saturating_add(self, rhs: Duration) -> Duration {
+        Duration(self.0.saturating_add(rhs.0))
+    }
+
+    #[inline]
+    pub fn checked_add(self, rhs: Duration) -> Option<Duration> {
+        self.0.checked_add(rhs.0).map(Duration::from)
+    }
+
+    #[inline]
+    pub fn saturating_sub(self, rhs: Duration) -> Duration {
+        Duration(self.0.saturating_sub(rhs.0))
+    }
+
+    #[inline]
+    pub fn checked_sub(self, rhs: Duration) -> Option<Duration> {
+        self.0.checked_sub(rhs.0).map(Duration::from)
+    }
+
+    #[inline]
+    pub fn saturating_mul(self, rhs: Duration) -> Duration {
+        Duration(self.0.saturating_mul(rhs.0))
+    }
+
+    #[inline]
+    pub fn checked_mul(self, rhs: Duration) -> Option<Duration> {
+        self.0.checked_mul(rhs.0).map(Duration::from)
+    }
+
+    #[inline]
+    pub fn checked_div(self, rhs: Duration) -> Option<Duration> {
+        self.0.checked_div(rhs.0).map(Duration::from)
+    }
 }
 
 #[doc(hidden)]

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -160,18 +160,18 @@ impl Duration {
     }
 
     #[inline]
-    pub fn saturating_mul(self, rhs: Duration) -> Duration {
-        Duration(self.0.saturating_mul(rhs.0))
+    pub fn saturating_mul(self, rhs: u32) -> Duration {
+        Duration(self.0.saturating_mul(rhs as u64))
     }
 
     #[inline]
-    pub fn checked_mul(self, rhs: Duration) -> Option<Duration> {
-        self.0.checked_mul(rhs.0).map(Duration)
+    pub fn checked_mul(self, rhs: u32) -> Option<Duration> {
+        self.0.checked_mul(rhs as u64).map(Duration)
     }
 
     #[inline]
-    pub fn checked_div(self, rhs: Duration) -> Option<Duration> {
-        self.0.checked_div(rhs.0).map(Duration)
+    pub fn checked_div(self, rhs: u32) -> Option<Duration> {
+        self.0.checked_div(rhs as u64).map(Duration)
     }
 }
 

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -139,36 +139,43 @@ impl Duration {
         Duration(self.0.abs_diff(other.0))
     }
 
+    /// Add two durations, saturating on overflow
     #[inline]
     pub fn saturating_add(self, rhs: Duration) -> Duration {
         Duration(self.0.saturating_add(rhs.0))
     }
 
+    /// Add two durations, returning `None` on overflow
     #[inline]
     pub fn checked_add(self, rhs: Duration) -> Option<Duration> {
         self.0.checked_add(rhs.0).map(Duration)
     }
 
+    /// Subtract two durations, saturating on underflow/overflow
     #[inline]
     pub fn saturating_sub(self, rhs: Duration) -> Duration {
         Duration(self.0.saturating_sub(rhs.0))
     }
 
+    /// Subtract two durations, returning `None` on underflow/overflow
     #[inline]
     pub fn checked_sub(self, rhs: Duration) -> Option<Duration> {
         self.0.checked_sub(rhs.0).map(Duration)
     }
 
+    /// Multiply a duration by a scalar, saturating on overflow
     #[inline]
     pub fn saturating_mul(self, rhs: u32) -> Duration {
         Duration(self.0.saturating_mul(rhs as u64))
     }
 
+    /// Multiply a duration by a scalar, returning `None` on overflow
     #[inline]
     pub fn checked_mul(self, rhs: u32) -> Option<Duration> {
         self.0.checked_mul(rhs as u64).map(Duration)
     }
 
+    /// Divide a duration by a scalar, returning `None` for division by zero
     #[inline]
     pub fn checked_div(self, rhs: u32) -> Option<Duration> {
         self.0.checked_div(rhs as u64).map(Duration)

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -5,6 +5,11 @@ use std::time;
 use super::helpers::*;
 
 /// A duration type to represent an approximate span of time
+///
+/// # Panics
+///
+/// Arithmetic on this type panics on overflow/underflow.
+/// If this is not desired, use the `.saturating_...` or `.checked_...` methods.
 #[derive(Copy, Clone, Debug, Hash, Ord, Eq, PartialOrd, PartialEq, Default)]
 pub struct Duration(u64);
 

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -146,7 +146,7 @@ impl Duration {
 
     #[inline]
     pub fn checked_add(self, rhs: Duration) -> Option<Duration> {
-        self.0.checked_add(rhs.0).map(Duration::from)
+        self.0.checked_add(rhs.0).map(Duration)
     }
 
     #[inline]
@@ -156,7 +156,7 @@ impl Duration {
 
     #[inline]
     pub fn checked_sub(self, rhs: Duration) -> Option<Duration> {
-        self.0.checked_sub(rhs.0).map(Duration::from)
+        self.0.checked_sub(rhs.0).map(Duration)
     }
 
     #[inline]
@@ -166,12 +166,12 @@ impl Duration {
 
     #[inline]
     pub fn checked_mul(self, rhs: Duration) -> Option<Duration> {
-        self.0.checked_mul(rhs.0).map(Duration::from)
+        self.0.checked_mul(rhs.0).map(Duration)
     }
 
     #[inline]
     pub fn checked_div(self, rhs: Duration) -> Option<Duration> {
-        self.0.checked_div(rhs.0).map(Duration::from)
+        self.0.checked_div(rhs.0).map(Duration)
     }
 }
 

--- a/src/instant.rs
+++ b/src/instant.rs
@@ -154,7 +154,7 @@ impl Instant {
     }
 
     #[inline]
-    pub fn checked_sub(self, rhs: Instant) -> Option<Instant> {
+    pub fn checked_sub(self, rhs: Duration) -> Option<Instant> {
         self.0.checked_sub(rhs.as_u64()).map(Instant)
     }
 

--- a/src/instant.rs
+++ b/src/instant.rs
@@ -154,10 +154,22 @@ impl Instant {
         self.0
     }
 
+    /// Calculate an `Instant` that is a `Duration` later, saturating on overflow
+    #[inline]
+    pub fn saturating_add(self, rhs: Duration) -> Instant {
+        Instant(self.0.saturating_add(rhs.as_u64()))
+    }
+
     /// Calculate an `Instant` that is a `Duration` later, returning `None` on overflow
     #[inline]
     pub fn checked_add(self, rhs: Duration) -> Option<Instant> {
         self.0.checked_add(rhs.as_u64()).map(Instant)
+    }
+
+    /// Calculate an `Instant` that is a `Duration` earlier, saturating on underflow
+    #[inline]
+    pub fn saturating_sub(self, rhs: Duration) -> Instant {
+        Instant(self.0.saturating_sub(rhs.as_u64()))
     }
 
     /// Calculate an `Instant` that is a `Duration` earlier, returning `None` on underflow

--- a/src/instant.rs
+++ b/src/instant.rs
@@ -98,11 +98,17 @@ impl Instant {
         *self - earlier
     }
 
+    /// Returns the interval between the two instants, saturating on under/overflow
+    ///
+    /// If `earlier` is actually later than `self`, returns zero.
     #[inline]
     pub fn saturating_duration_since(&self, earlier: Instant) -> Duration {
         Duration::from_u64(self.0.saturating_sub(earlier.0))
     }
 
+    /// Returns the interval between the two instants, returning `None` on under/overflow
+    ///
+    /// If `earlier` is actually later than `self`, returns `None`.
     #[inline]
     pub fn checked_duration_since(&self, earlier: Instant) -> Option<Duration> {
         self.0.checked_sub(earlier.0).map(Duration::from_u64)
@@ -148,11 +154,13 @@ impl Instant {
         self.0
     }
 
+    /// Calculate an `Instant` that is a `Duration` later, returning `None` on overflow
     #[inline]
     pub fn checked_add(self, rhs: Duration) -> Option<Instant> {
         self.0.checked_add(rhs.as_u64()).map(Instant)
     }
 
+    /// Calculate an `Instant` that is a `Duration` earlier, returning `None` on underflow
     #[inline]
     pub fn checked_sub(self, rhs: Duration) -> Option<Instant> {
         self.0.checked_sub(rhs.as_u64()).map(Instant)

--- a/src/instant.rs
+++ b/src/instant.rs
@@ -98,6 +98,16 @@ impl Instant {
         *self - earlier
     }
 
+    #[inline]
+    pub fn saturating_duration_since(&self, earlier: Instant) -> Duration {
+        Duration::from_u64(self.0.saturating_sub(earlier.0))
+    }
+
+    #[inline]
+    pub fn checked_duration_since(&self, earlier: Instant) -> Option<Duration> {
+        self.0.checked_sub(earlier.0).map(Duration::from_u64)
+    }
+
     /// Returns the amount of time elapsed between the this instant was created
     /// and the latest update
     #[inline]
@@ -136,6 +146,16 @@ impl Instant {
     #[inline]
     pub fn as_u64(&self) -> u64 {
         self.0
+    }
+
+    #[inline]
+    pub fn checked_add(self, rhs: Duration) -> Option<Instant> {
+        self.0.checked_add(rhs.as_u64()).map(Instant)
+    }
+
+    #[inline]
+    pub fn checked_sub(self, rhs: Instant) -> Option<Instant> {
+        self.0.checked_sub(rhs.as_u64()).map(Instant)
     }
 
     #[cfg(any(target_os = "linux", target_os = "android"))]

--- a/src/instant.rs
+++ b/src/instant.rs
@@ -14,6 +14,11 @@ use super::helpers::*;
 /// Resulting durations are actual durations; they do not get affected by
 /// clock adjustments, leap seconds, or similar.
 /// In order to get a measurement of the *wall clock*, use `Date` instead.
+///
+/// # Panics
+///
+/// Arithmetic on this type panics on overflow/underflow.
+/// If this is not desired, use the `.saturating_...` or `.checked_...` methods.
 #[derive(Copy, Clone, Debug, Hash, Ord, Eq, PartialOrd, PartialEq)]
 pub struct Instant(u64);
 


### PR DESCRIPTION
This is basically the same as #20, but improved.  I took the branch from #20, rebased it, corrected mistakes, and added docs.

The code is a bit formulaic, sorry.  I considered using macros but thought the result would be worse.