### PR TITLE
Add `from_ticks` method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coarsetime"
-version = "0.1.36"
+version = "0.1.37"
 description = "Time and duration crate optimized for speed"
 authors = ["Frank Denis <github@pureftpd.org>"]
 keywords = ["time", "date", "duration"]

--- a/src/instant.rs
+++ b/src/instant.rs
@@ -139,6 +139,16 @@ impl Instant {
         self.0
     }
 
+    /// Returns an instant corresponding to `ticks`.
+    /// See [`as_ticks()`][Instant::as_ticks]
+    ///
+    /// This API is mainly intended for applications that need to
+    /// restore a previous instance of an `Instant` from an
+    /// [`AtomicU64`](std::sync::atomic::AtomicU64).
+    pub fn from_ticks(ticks: u64) -> Self {
+        Instant(ticks)
+    }
+
     /// Calculate an `Instant` that is a `Duration` later, saturating on overflow
     #[inline]
     pub fn saturating_add(self, rhs: Duration) -> Instant {


### PR DESCRIPTION
Fixes https://github.com/jedisct1/rust-coarsetime/issues/38

Also bumps version to v0.1.37